### PR TITLE
Add info for contributers

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at community(at)datengui.de. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-TODO: Add contributor guidelines

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Datenguide is your guide to understanding and using German official statistics. We work on an easy-to-use data portal and on learning materials around data published by the German statistics offices. Datenguide is in early stages and is bound to change heavily over the next couple of weeks. See the [roadmap](https://github.com/datenguide/datenguide/issues/1) for details.
+Datenguide is your guide to understanding and using German official statistics. We work on an easy-to-use data portal and on learning materials around data published by the German statistics offices. 
 
 ### Mission statement (draft)
 
@@ -30,6 +30,23 @@ In Germany, official statistics are collected, processed, analyzed, and publishe
 The problem with the official data portals is that they are expert systems, made by and for bureaucrats. While these data portals get the job done for people who know what they are doing, they are hardly usable for less tech- and data-savy people. Also, none of the data portals provide modern, easy-to-use APIs or machine-readable data formats, which makes it hard to use the data in your own work.
 
 This is where Datenguide comes in. We are working on a modern, easy-to-use data portal aimed at regular people. A website that allows for exploratory browsing, provides explanations and context about the statistics, and lets you download data sets in formats that you can readily use in your own projects.
+
+### Contributing
+
+We are actively seeking contributors for this project – civic technologists, designers, developers, researchers, and data journalists. If you want to help making official statistics more usable, get in touch! ([email](mailto:sj@datengui.de) / [twitter](https://twitter.de/datenguide))
+
+Ways to support the Datenguide project:
+
+- Contribute to the [datengui.de web application](https://github.com/datenguide/datenguide-frontend) (JavaScript/React)
+- Help us improve our [backend and API](https://github.com/datenguide/datenguide-backend) (Python/Flask)
+- Help with organizing a workshop or hackathon around open data and official statistics
+- Write documentation, tutorials, or blog posts
+
+Datenguide is still in early stages and is bound to change heavily over the next couple of weeks. See our [roadmap](https://github.com/datenguide/datenguide/issues/1) for details. For bugs and feature requests, please [create an issue](https://github.com/datenguide/datenguide/issues/new). When contributing to the Datenguide project, please observe our [code of conduct](https://github.com/datenguide/datenguide/blob/master/CODE_OF_CONDUCT).
+
+### License
+
+Datenguide is an open data project built on open source software. The documentation in this repository is published under a [Creative Commons Attribution 4.0 International License (CC By 4.0)](https://creativecommons.org/licenses/by/4.0/). The Datenguide source code is published under a [MIT License](https://github.com/datenguide/datenguide-frontend/blob/master/LICENSE). The official statistics used in the Datenguide project are licensed under [Data Licence Germany – Attribution – Version 2.0 (dl-de/by-2-0)](https://www.govdata.de/en/dl-de/by-2-0), the official German open data license, by the [statistical offices of Germany](https://www.regionalstatistik.de/).
 
 ### More about this project
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,7 +1,0 @@
----
-layout: page
-title: Roadmap
-permalink: /roadmap/
----
-
-This project was started as part of a bigger project help activists to learn about **privacy** and **anonimity** on their communications and technology use. There's a lot of content created by technologists about those topics, but there are not easy or enjoyable for a lot of people.


### PR DESCRIPTION
Add info for (potential) contributors and a code of conduct based on the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org).