### PR TITLE
Quick fix for 500-XHR, when data table without measure

### DIFF
--- a/src/components/querytool/DataTable.js
+++ b/src/components/querytool/DataTable.js
@@ -138,6 +138,16 @@ const DataTable = ({
       setLoading(true)
       // // TODO support more than 1 measure
       const measure = Object.values(measures)[0]
+
+      // Fixes the rare case, that "data" key was not present
+      if (
+        Object.keys(router.query).includes('') &&
+        !Object.keys(router.query).includes('data')
+      ) {
+        router.query.data = measure.id
+        delete router.query['']
+      }
+
       const query = getQuery(
         regions,
         measure,
@@ -146,6 +156,7 @@ const DataTable = ({
         page,
         rowsPerPage
       )
+
       setGraphqlQuery(query)
       // const response = await client.request({ query })
       // const { data, error } = response


### PR DESCRIPTION
Thank you for the great tool!
As mentioned above this is a quick fix for the 500-XHR, when "data" keys is not in router.query and therefore the JSON error (from the XHR call with 500 status) is printed into the DataTable pane. You can witness the error an the most recent version of https://datengui.de/statistiken, if you add any measure, remove it and add any measure again. Than after ca. 30s you will see XHR-500 in your dev console and the JSON-error message in the DataTable pane.

If you log `querystring.stringify(router.query)` in the same method, it will make the behavior also transparent.

The if condition may not be perfect, but it fits the case of not having a "data" key and having a "" key in the query object.